### PR TITLE
Add NodeJs version requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The value of collateral you get will be `the value of the loan you repay` \* (10
 
 ### Version Requirements
 
+- Nodejs > `v15.0`
 - Anchor `v0.18.0`
 - Solana `v1.7.8`
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # ⏰ Sundial
 
-Sundial enables fixed rate borrowing and lending on Solana. 
+Sundial enables fixed rate borrowing and lending on Solana.
 
 It tokenizes a user's position on Port into two parts:
+
 - principal tokens (maps one-to-one to the underlying token)
 - yield tokens (variable part which depends on the yield of the underlying protocols)
 
 At maturity 1 principal tokens allow users to exchange for 1 underlying tokens. 1 yield tokens allow users to redeem the interest earned during the loan period.
 
 ## Usage
+
 ### Fixed Rate Lending & Borrowing
+
 Principal tokens can be used to implement fixed rate lending using a zero coupon bond model, since principal tokens can always be redeemed one to one to the underlying.
 
 Users can trade principal tokens in various DEX. The seller of the principal tokens can be considered as borrower while the buyers can be considered as lender.
@@ -23,9 +26,11 @@ Interest Paid = the difference between the Principal USDC price and 1
 Say 1 Principal USDC (ppUSDC) is traded at 0.95 USDC. Then the interest that the lender is going to receive or borrower is going to pay is (1 - 0.95) = 0.05 USDC. Users can then annualize it to calculate the APY.
 
 ### Interest Rate Swap
+
 Since the yield tokens always maps to the lending interest rate over a given period. The buyer of the yield tokens can be considered as giving up fixed rate in favor of floating rate. The seller of the yield tokens can be considered as giving up the floating rate in favor of the fixed rate.
 
 ## User Interactions
+
 Users can create [Profile] to deposit Port LP tokens as collateral and mint Principal Token (ppToken) directly from Sundial and sell them in market for underlying, which is equivalent to borrow at a fixed rate.
 
 Users must repay the liquidity that corresponds to the ppToken they minted before ppToken matures, i.e. the sundial pool ends. Otherwise, users will be liquidated by others.
@@ -37,39 +42,43 @@ To refresh sundial collateral, you need to refresh the corresponded reserve befo
 They will become stale after 10 slots.
 
 ## Liquidation
+
 For liquidation, you need choose a certain sundial profile that you want to liquidate, and the loan you want to repay, and the collateral you want to withdraw,
 and refresh all the sundial collaterals in it, then send the liquidation transaction.
 
 The on-chain program checks if the liquidation can be performed. If so, users repay the loan and withdraw the collateral with a bonus.
 
-The value of collateral you get will be `the value of the loan you repay` * (100 + `liquidation penalty of that collateral`).
-
+The value of collateral you get will be `the value of the loan you repay` \* (100 + `liquidation penalty of that collateral`).
 
 ## Development
 
 ### Version Requirements
+
 - Anchor `v0.18.0`
 - Solana `v1.7.8`
 
 ### To start a front-end test environment
 
 ```
+npm install -g ts-node
 anchor localnet
 ```
 
 In a separate terminal run the following command to set up all the on-chain program:
+
 ```
 anchor migrate
 ```
 
-
 ### To run the tests locally
+
 ```
 yarn idl:generate
 yarn test:e2e
 ```
 
 Mac users need to install GNU Sed for `yarn idl:generate` to work properly.
+
 ```
 brew install gnu-sed
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "dist/esm/index.js",
   "license": "AGPL-3.0",
   "repository": "git@github.com:port-finance/sundial.git",
+  "engines": {
+    "node": ">=15.0.0"
+  },
   "scripts": {
     "idl:generate": "./scripts/parse-idls.sh && ./scripts/generate-idl-types.sh",
     "build": "rm -fr dist/ && tsc -P tsconfig.build.json && tsc -P tsconfig.esm.json",


### PR DESCRIPTION
Dependence @saberhq/solana-contrib uses AggregateError API which is introduced after Node v15.0. 
Add requirements to Readme and package.json.
<img width="609" alt="image" src="https://user-images.githubusercontent.com/39836367/161371411-7a32a831-418e-4717-ae36-8586a2102492.png">
